### PR TITLE
Fix use of sendmmsg()

### DIFF
--- a/aeron-driver/src/main/c/agent/aeron_driver_agent.c
+++ b/aeron-driver/src/main/c/agent/aeron_driver_agent.c
@@ -1487,7 +1487,7 @@ static const char *dissect_cmd_in(int64_t cmd_id, const void *message, size_t le
             snprintf(
                 buffer,
                 sizeof(buffer) - 1,
-                "streamId=%d clientId=%" PRId64 " correlationId=%" PRId64 " channel=%*.s",
+                "streamId=%d clientId=%" PRId64 " correlationId=%" PRId64 " channel=%.*s",
                 command->stream_id,
                 command->correlated.client_id,
                 command->correlated.correlation_id,

--- a/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
+++ b/aeron-driver/src/main/c/media/aeron_udp_channel_transport.c
@@ -102,7 +102,7 @@ int aeron_udp_channel_transport_init(
     {
         transport->interceptor_clientds[i] = NULL;
     }
-    
+
     if (NULL == params)
     {
         AERON_SET_ERR(EINVAL, "%s", "channel transport params is NULL");
@@ -594,12 +594,14 @@ static int aeron_udp_channel_transport_sendv(
     struct mmsghdr msg[AERON_NETWORK_PUBLICATION_MAX_MESSAGES_PER_SEND];
     size_t msg_i;
 
+    size_t msg_namelen = address == NULL ? 0 : AERON_ADDR_LEN(address);
+
     for (msg_i = 0; msg_i < iov_length && msg_i < AERON_NETWORK_PUBLICATION_MAX_MESSAGES_PER_SEND; msg_i++)
     {
         msg[msg_i].msg_hdr.msg_control = NULL;
         msg[msg_i].msg_hdr.msg_controllen = 0;
         msg[msg_i].msg_hdr.msg_name = address;
-        msg[msg_i].msg_hdr.msg_namelen = AERON_ADDR_LEN(address);
+        msg[msg_i].msg_hdr.msg_namelen = msg_namelen;
         msg[msg_i].msg_hdr.msg_flags = 0;
         msg[msg_i].msg_hdr.msg_iov = &iov[msg_i];
         msg[msg_i].msg_hdr.msg_iovlen = 1;
@@ -644,9 +646,16 @@ int aeron_udp_channel_transport_send(
     int64_t *bytes_sent)
 {
 #if defined(HAVE_SENDMMSG)
-    if (1 == iov_length && NULL != transport->connected_address)
+    if (NULL != transport->connected_address)
     {
-        return aeron_udp_channel_transport_send_connected(transport, iov, bytes_sent);
+        if (1 == iov_length)
+        {
+            return aeron_udp_channel_transport_send_connected(transport, iov, bytes_sent);
+        }
+        else
+        {
+            return aeron_udp_channel_transport_sendv(transport, NULL, iov, iov_length, bytes_sent);
+        }
     }
     else
     {


### PR DESCRIPTION
`aeron_udp_channel_transport_sendv()` calls `sendmmsg()` under the hood. `sendmmsg()` [manpage](https://manpages.ubuntu.com/manpages/focal/en/man2/send.2freebsd.html) says:

> [EISCONN]          A destination address was specified and the socket is already connected.

Looks like exasock takes it quite literally and returns an error even if specified destination address matches the connected address of the socket. Linux must be more relaxed about it and the old code works fine. I wasn't sure whether I should fix exasock or aeron and decided fixing aeron is simpler and also more compliant with manpage.
